### PR TITLE
Fix null values

### DIFF
--- a/src/main/scala/io/vertx/ext/asyncsql/impl/AsyncSqlConnectionImpl.scala
+++ b/src/main/scala/io/vertx/ext/asyncsql/impl/AsyncSqlConnectionImpl.scala
@@ -147,7 +147,11 @@ class AsyncSqlConnectionImpl(connection: Connection, pool: AsyncConnectionPool)(
     for {
       elem <- row
     } yield {
-      json.add(elem)
+      if (elem == null) {
+        json.addNull()
+      } else {
+        json.add(elem)
+      }
     }
     json
   }


### PR DESCRIPTION
This should fix #6. Is there a reason, why we can't do `json.add(null)` directly but need to use the separate method @purplefox ?