### PR TITLE
Date and time fix

### DIFF
--- a/src/main/java/io/vertx/ext/asyncsql/package-info.java
+++ b/src/main/java/io/vertx/ext/asyncsql/package-info.java
@@ -73,6 +73,11 @@
  *
  * You can learn how to use it in the http://foobar[common sql interface] documentation.
  *
+ * === Note about date and timestamps
+ *
+ * Whenever you get dates back from the database, this service will implicitly convert them into ISO 8601
+ * (`yyyy-MM-ddTHH:mm:ss.SSS`) formatted strings. MySQL usually discards milliseconds, so you will regularly see `.000`.
+ *
  * == Configuration
  *
  * Both the PostgreSql and MySql services take the same configuration:
@@ -98,8 +103,7 @@
  * `database`:: The name of the database you want to connect to. Defaults to `test`.
  */
 @Document(fileName = "index.adoc")
-@GenModule(name = "vertx-mysql-postgresql")
-package io.vertx.ext.asyncsql;
+@GenModule(name = "vertx-mysql-postgresql") package io.vertx.ext.asyncsql;
 
 import io.vertx.codegen.annotations.GenModule;
 import io.vertx.docgen.Document;

--- a/src/main/scala/io/vertx/ext/asyncsql/impl/AsyncSqlConnectionImpl.scala
+++ b/src/main/scala/io/vertx/ext/asyncsql/impl/AsyncSqlConnectionImpl.scala
@@ -147,7 +147,11 @@ class AsyncSqlConnectionImpl(connection: Connection, pool: AsyncConnectionPool)(
     for {
       elem <- row
     } yield {
-      json.add(elem)
+      if (elem == null) {
+        json.addNull()
+      } else {
+        json.add(elem)
+      }
     }
     json
   }

--- a/src/main/scala/io/vertx/ext/asyncsql/impl/AsyncSqlConnectionImpl.scala
+++ b/src/main/scala/io/vertx/ext/asyncsql/impl/AsyncSqlConnectionImpl.scala
@@ -6,6 +6,7 @@ import io.vertx.core.json.JsonArray
 import io.vertx.core.{AsyncResult, Future => VFuture, Handler}
 import io.vertx.ext.asyncsql.impl.pool.AsyncConnectionPool
 import io.vertx.ext.sql.{UpdateResult, ResultSet, SqlConnection}
+import org.joda.time.format.ISODateTimeFormat
 
 import scala.concurrent.{Future, ExecutionContext}
 import scala.util.{Failure, Success, Try}
@@ -147,10 +148,11 @@ class AsyncSqlConnectionImpl(connection: Connection, pool: AsyncConnectionPool)(
     for {
       elem <- row
     } yield {
-      if (elem == null) {
-        json.addNull()
-      } else {
-        json.add(elem)
+      elem match {
+        case null => json.addNull()
+        case localDateTime: org.joda.time.LocalDateTime => json.add(localDateTime.toString)
+        case localDate: org.joda.time.LocalDate => json.add(localDate.toString)
+        case other => json.add(other)
       }
     }
     json

--- a/src/test/scala/io/vertx/ext/asyncsql/MysqlConfig.scala
+++ b/src/test/scala/io/vertx/ext/asyncsql/MysqlConfig.scala
@@ -6,7 +6,12 @@ import io.vertx.core.json.JsonObject
  * @author <a href="http://www.campudus.com">Joern Bernhardt</a>.
  */
 trait MysqlConfig extends ConfigProvider {
+  this: SqlTestBase =>
+
   override val address = "campudus.mysql"
 
   override val config: JsonObject = new JsonObject().put("address", address)
+
+  override val dateTimeInUtc1 = "2015-02-22T07:15:01.000"
+  override val dateTimeInUtc2 = "2014-06-27T17:50:02.000"
 }

--- a/src/test/scala/io/vertx/ext/asyncsql/MysqlScalaTest.scala
+++ b/src/test/scala/io/vertx/ext/asyncsql/MysqlScalaTest.scala
@@ -7,5 +7,4 @@ class MysqlScalaTest extends DirectTestBase with MysqlConfig {
 
   override lazy val asyncSqlService = AsyncSqlService.createMySqlService(vertx, config)
 
-
 }

--- a/src/test/scala/io/vertx/ext/asyncsql/PostgresqlConfig.scala
+++ b/src/test/scala/io/vertx/ext/asyncsql/PostgresqlConfig.scala
@@ -6,6 +6,8 @@ import io.vertx.core.json.JsonObject
  * @author <a href="http://www.campudus.com">Joern Bernhardt</a>.
  */
 trait PostgresqlConfig extends ConfigProvider {
+  this: SqlTestBase =>
+
   override val address = "campudus.postgresql"
 
   override val config: JsonObject = new JsonObject().put("address", address)


### PR DESCRIPTION
This includes #7, so I'll close the other PR.

@purplefox please review.

It looks like MySQL doesn't store milliseconds in timestamps, so they are lost. Anyways, better than having no date and time at all, I guess?